### PR TITLE
MP2-135 Remove countdown from tremor to match new designs

### DIFF
--- a/MotorControl/MotorControl/Resources/TremorSectionStep.json
+++ b/MotorControl/MotorControl/Resources/TremorSectionStep.json
@@ -28,26 +28,6 @@
                     }
               },
               {
-                  "identifier":"countdown",
-                  "type":"countdown",
-                  "text":"Begin in...",
-                  "image":{
-                      "type":"fetchable",
-                      "imageName":"HoldPhone-Left",
-                      "placementType":"fullsizeBackground"
-                  },
-                  "viewTheme":{
-                      "viewIdentifier":"Countdown",
-                      "storyboardIdentifier":"ActiveTaskSteps"
-                  },
-                  "colorMapping":{
-                      "type": "singleColor",
-                      "colorStyle": "primary"
-                  },
-                  "duration":5,
-                  "commands":["playSoundOnStart", "transitionAutomatically"]
-              },
-              {
                   "identifier":"tremor",
                   "type":"active",
                   "duration":30,


### PR DESCRIPTION
Latest designs no longer include a countdown for the tremor test.