### PR TITLE
Update Sage Research to 2.0

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "Sage-Bionetworks/SageResearch" ~> 1.3.33
+github "Sage-Bionetworks/SageResearch" ~> 2.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "Sage-Bionetworks/SageResearch" "v1.3.34"
+github "Sage-Bionetworks/SageResearch" "v2.0.41"

--- a/MCTSampleApp/MCTSampleApp.xcodeproj/project.pbxproj
+++ b/MCTSampleApp/MCTSampleApp.xcodeproj/project.pbxproj
@@ -24,8 +24,8 @@
 		F82CEF28227AB675000485C8 /* Research.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F82CEF26227AB675000485C8 /* Research.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F82CEF2A227AB675000485C8 /* ResearchUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F82CEF29227AB675000485C8 /* ResearchUI.framework */; };
 		F82CEF2B227AB675000485C8 /* ResearchUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F82CEF29227AB675000485C8 /* ResearchUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		F82CEF2D227AB675000485C8 /* ResearchRecorders.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F82CEF2C227AB675000485C8 /* ResearchRecorders.framework */; };
-		F82CEF2E227AB675000485C8 /* ResearchRecorders.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F82CEF2C227AB675000485C8 /* ResearchRecorders.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		F8E12677228E346400AE37E1 /* ResearchMotion.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8E12676228E346400AE37E1 /* ResearchMotion.framework */; };
+		F8E12678228E346400AE37E1 /* ResearchMotion.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F8E12676228E346400AE37E1 /* ResearchMotion.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -46,7 +46,7 @@
 			dstSubfolderSpec = 10;
 			files = (
 				F82CEF25227AB675000485C8 /* MotorControl.framework in Embed Frameworks */,
-				F82CEF2E227AB675000485C8 /* ResearchRecorders.framework in Embed Frameworks */,
+				F8E12678228E346400AE37E1 /* ResearchMotion.framework in Embed Frameworks */,
 				F82CEF28227AB675000485C8 /* Research.framework in Embed Frameworks */,
 				F82CEF2B227AB675000485C8 /* ResearchUI.framework in Embed Frameworks */,
 			);
@@ -74,7 +74,7 @@
 		F82CEF23227AB675000485C8 /* MotorControl.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = MotorControl.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F82CEF26227AB675000485C8 /* Research.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Research.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F82CEF29227AB675000485C8 /* ResearchUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = ResearchUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		F82CEF2C227AB675000485C8 /* ResearchRecorders.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = ResearchRecorders.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F8E12676228E346400AE37E1 /* ResearchMotion.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = ResearchMotion.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -83,7 +83,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F82CEF24227AB675000485C8 /* MotorControl.framework in Frameworks */,
-				F82CEF2D227AB675000485C8 /* ResearchRecorders.framework in Frameworks */,
+				F8E12677228E346400AE37E1 /* ResearchMotion.framework in Frameworks */,
 				F82CEF27227AB675000485C8 /* Research.framework in Frameworks */,
 				F82CEF2A227AB675000485C8 /* ResearchUI.framework in Frameworks */,
 			);
@@ -148,7 +148,7 @@
 		F82CEF22227AB61A000485C8 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				F82CEF2C227AB675000485C8 /* ResearchRecorders.framework */,
+				F8E12676228E346400AE37E1 /* ResearchMotion.framework */,
 				F82CEF29227AB675000485C8 /* ResearchUI.framework */,
 				F82CEF26227AB675000485C8 /* Research.framework */,
 				F82CEF23227AB675000485C8 /* MotorControl.framework */,

--- a/MotorControl/MotorControl.xcodeproj/project.pbxproj
+++ b/MotorControl/MotorControl.xcodeproj/project.pbxproj
@@ -14,9 +14,9 @@
 		F813D6FF21BB416C00795664 /* MCTFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = F813D6FD21BB416C00795664 /* MCTFactory.swift */; };
 		F813D70E21BB419E00795664 /* NavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F813D70C21BB419D00795664 /* NavigationTests.swift */; };
 		F813D70F21BB419E00795664 /* ResourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F813D70D21BB419E00795664 /* ResourceTests.swift */; };
-		F82CEF31227AB68A000485C8 /* ResearchRecorders.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F82CEF30227AB68A000485C8 /* ResearchRecorders.framework */; };
 		F837224B223320B400C9A2EA /* MCTHandInstructionStepObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = F837224A223320B400C9A2EA /* MCTHandInstructionStepObject.swift */; };
 		F8C36BCB223881A3000E42A7 /* MCTTaskObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8C36BCA223881A3000E42A7 /* MCTTaskObject.swift */; };
+		F8E12675228E344800AE37E1 /* ResearchMotion.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8E12674228E344800AE37E1 /* ResearchMotion.framework */; };
 		F8E3B7FA21BB45010004284E /* Research.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8E3B7F921BB45010004284E /* Research.framework */; };
 		F8E3B7FC21BB450B0004284E /* ResearchUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8E3B7FB21BB450B0004284E /* ResearchUI.framework */; };
 		F8E3B80821BB45630004284E /* Research_UnitTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8E3B80721BB45630004284E /* Research_UnitTest.framework */; };
@@ -65,6 +65,7 @@
 		F82CEF30227AB68A000485C8 /* ResearchRecorders.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = ResearchRecorders.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F837224A223320B400C9A2EA /* MCTHandInstructionStepObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCTHandInstructionStepObject.swift; sourceTree = "<group>"; };
 		F8C36BCA223881A3000E42A7 /* MCTTaskObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCTTaskObject.swift; sourceTree = "<group>"; };
+		F8E12674228E344800AE37E1 /* ResearchMotion.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = ResearchMotion.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8E3B7F921BB45010004284E /* Research.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Research.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8E3B7FB21BB450B0004284E /* ResearchUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = ResearchUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8E3B80721BB45630004284E /* Research_UnitTest.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Research_UnitTest.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -94,7 +95,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F82CEF31227AB68A000485C8 /* ResearchRecorders.framework in Frameworks */,
+				F8E12675228E344800AE37E1 /* ResearchMotion.framework in Frameworks */,
 				F8E3B7FC21BB450B0004284E /* ResearchUI.framework in Frameworks */,
 				F8E3B7FA21BB45010004284E /* Research.framework in Frameworks */,
 			);
@@ -163,6 +164,7 @@
 		F8E3B7F821BB45010004284E /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				F8E12674228E344800AE37E1 /* ResearchMotion.framework */,
 				F82CEF30227AB68A000485C8 /* ResearchRecorders.framework */,
 				F8E3B80721BB45630004284E /* Research_UnitTest.framework */,
 				F8E3B7FB21BB450B0004284E /* ResearchUI.framework */,

--- a/MotorControl/MotorControl/MCTFactory.swift
+++ b/MotorControl/MotorControl/MCTFactory.swift
@@ -38,17 +38,17 @@ extension RSDStepType {
     public static let handInstruction: RSDStepType = "handInstruction"
 }
 
-fileprivate var _didAddLocalizationBundle: Bool = false
+fileprivate var _didLoad: Bool = false
 
 open class MCTFactory : RSDFactory {
     
-    /// The default color palette for this module is royal500, butterscotch500 without an accent color.
-    /// The design system is set as version 0.
+    /// The default color palette for this module is Royal 300, Butterscotch 300, Turquoise 300
+    /// The design system is set as version 1.
     public static let designSystem: RSDDesignSystem = {
         let primary = RSDColorMatrix.shared.colorKey(for: .palette(.royal), shade: .medium)
         let secondary = RSDColorMatrix.shared.colorKey(for: .palette(.butterscotch), shade: .medium)
         let accent = RSDColorMatrix.shared.colorKey(for: .palette(.turquoise), shade: .medium)
-        let palette = RSDColorPalette(version: 1, primary: primary, secondary: secondary, accent: primary)
+        let palette = RSDColorPalette(version: 1, primary: primary, secondary: secondary, accent: accent)
         return RSDDesignSystem(palette: palette)
     }()
     
@@ -56,11 +56,15 @@ open class MCTFactory : RSDFactory {
     public override init() {
         super.init()
         
-        // Add the localization bundle if this is a first init()
-        if !_didAddLocalizationBundle {
-            _didAddLocalizationBundle = true
+        if !_didLoad {
+            _didLoad = true
+            
+            // Add the localization bundle if this is a first init()
             let localizationBundle = LocalizationBundle(Bundle(for: MCTFactory.self))
             Localization.insert(bundle: localizationBundle, at: 1)
+            
+            // Register authorization handlers
+            RSDAuthorizationHandler.registerAdaptorIfNeeded(RSDMotionAuthorization.shared)
         }
     }
         

--- a/MotorControl/MotorControl/MotorControl.h
+++ b/MotorControl/MotorControl/MotorControl.h
@@ -34,6 +34,7 @@
 @import UIKit;
 @import Research;
 @import ResearchUI;
+@import ResearchMotion;
 
 //! Project version number for MotorControl.
 FOUNDATION_EXPORT double MotorControlVersionNumber;


### PR DESCRIPTION
Updates Sage Research to new framework structure, but also requires any app that uses this to embed a different set of frameworks.

Required Frameworks: Research, ResearchUI, ResearchMotion
Required Privacy Keys: Motion sensors

Note: This does not yet address the issue of allowing Walk & Balance to run with the phone locked, nor does it cancel the task if the user answers a phone call.