### PR TITLE
Localize the handling of the image and text

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,11 +3,11 @@
     "pins": [
       {
         "package": "AssessmentModel",
-        "repositoryURL": "/Users/arabara/Github/AssessmentModelKMM",
+        "repositoryURL": "https://github.com/Sage-Bionetworks/AssessmentModelKMM.git",
         "state": {
           "branch": null,
-          "revision": "4e59146cb5f9aaffa119dcb15778c7467c5574c4",
-          "version": "0.8.4"
+          "revision": "65cd9ee57f75f56bcd148b828de53110f8d7eefe",
+          "version": "0.8.6"
         }
       },
       {

--- a/Sources/MotorControl/Model/TwoHandAssessmentObject.swift
+++ b/Sources/MotorControl/Model/TwoHandAssessmentObject.swift
@@ -163,7 +163,7 @@ final class TwoHandNavigator : Navigator {
     }
 }
 
-enum HandSelection: String, Codable, CaseIterable {
+public enum HandSelection: String, Codable, CaseIterable {
     case left, right
 }
 

--- a/Sources/MotorControlUI/InstructionView.swift
+++ b/Sources/MotorControlUI/InstructionView.swift
@@ -38,7 +38,7 @@ import MotorControl
 import SharedResources
 
 struct InstructionView: View {
-    let nodeState: InstructionState
+    let nodeState: MotorControlInstructionState
     
     var body: some View {
         VStack {
@@ -54,7 +54,10 @@ struct InstructionView: View {
 struct InstructionView_Previews: PreviewProvider {
     static var previews: some View {
         Group {
-            InstructionView(nodeState: InstructionState(example1, parentId: nil))
+            InstructionView(nodeState: MotorControlInstructionState(example1, parentId: nil))
+                .environmentObject(PagedNavigationViewModel(pageCount: 5, currentIndex: 0))
+                .environmentObject(AssessmentState(AssessmentObject(previewStep: example1)))
+            InstructionView(nodeState: MotorControlInstructionState(example1, parentId: nil, whichHand: .right))
                 .environmentObject(PagedNavigationViewModel(pageCount: 5, currentIndex: 0))
                 .environmentObject(AssessmentState(AssessmentObject(previewStep: example1)))
             
@@ -73,8 +76,7 @@ struct InstructionNodeView: View {
     
     @SwiftUI.Environment(\.surveyTintColor) var surveyTint: Color
     @SwiftUI.Environment(\.spacing) var spacing: CGFloat
-    @ObservedObject var contentInfo: InstructionState
-    fileprivate let right = "right"
+    @ObservedObject var contentInfo: MotorControlInstructionState
     
     var body: some View {
         GeometryReader { scrollViewGeometry in
@@ -82,29 +84,26 @@ struct InstructionNodeView: View {
                 ScrollView {
                     VStack(alignment: .center, spacing: spacing) {
                         if let imageInfo = contentInfo.contentNode.imageInfo {
-                            if let title = contentInfo.title, title.lowercased().contains(right) {
-                                ContentImage(imageInfo)
-                                    .background(surveyTint)
-                                    .rotation3DEffect(.degrees(180), axis: (x: CGFloat(0), y: CGFloat(1), z: CGFloat(0)))
-                            }
-                            else {
-                                ContentImage(imageInfo)
-                                    .background(surveyTint)
-                            }
+                            ContentImage(imageInfo)
+                                .background(surveyTint)
+                                .rotation3DEffect(.degrees(contentInfo.flippedImage ? 180 : 0), axis: (x: CGFloat(0), y: CGFloat(1), z: CGFloat(0)))
                         }
                         if let title = contentInfo.title {
                             Text(title)
                                 .font(.stepTitle)
+                                .foregroundColor(.textForeground)
                                 .fixedSize(horizontal: false, vertical: true)
                         }
                         if let subtitle = contentInfo.subtitle {
                             Text(subtitle)
                                 .font(.stepSubtitle)
+                                .foregroundColor(.textForeground)
                                 .multilineTextAlignment(.center)
                         }
                         if let detail = contentInfo.detail {
                             Text(detail)
                                 .font(.stepDetail)
+                                .foregroundColor(.textForeground)
                                 .multilineTextAlignment(.center)
                         }
                     }

--- a/Sources/MotorControlUI/MotorControlAssessmentView.swift
+++ b/Sources/MotorControlUI/MotorControlAssessmentView.swift
@@ -92,7 +92,7 @@ public struct MotorControlAssessmentView : View {
             else if state.step is OverviewStep {
                 OverviewView(nodeState: state)
             }
-            else if let nodeState = state as? InstructionState {
+            else if let nodeState = state as? MotorControlInstructionState {
                 InstructionView(nodeState: nodeState)
             }
             else {


### PR DESCRIPTION
```
if let title = contentInfo.title, title.lowercased().contains(right) {
    ContentImage(imageInfo)
        .background(surveyTint)
        .rotation3DEffect(.degrees(180), axis: (x: CGFloat(0), y: CGFloat(1), z: CGFloat(0)))
}
else {
    ContentImage(imageInfo)
        .background(surveyTint)
}
```

Consider what this chunk of code is doing. Since it relies upon a search for the word "right" it will fail for a language that is not English. Additionally, an instruction with the title "Turn to the right" has a very different meaning and should probably *not* include flipping the image. Finally, duplicating your code in order to add the flip if and only if the image should be flipped (ie. "right") means that you are copy/pasting which can introduce bugs where the only thing you really want to do is flip the image.

If you accept this code change, you can go ahead and merge it into your branch. Sometimes this is an easier way of suggesting code changes than trying to use GitHub pull requests. :)   